### PR TITLE
Fixed Doxygen Comment Inconsistencies

### DIFF
--- a/jack.h
+++ b/jack.h
@@ -404,8 +404,8 @@ int jack_set_port_registration_callback (jack_client_t *,
 
 
 /**
- * Tell the JACK server to call @a registration_callback whenever a
- * port is registered or unregistered, passing @a arg as a parameter.
+ * Tell the JACK server to call @a rename_callback whenever a
+ * port is renamed, passing @a arg as a parameter.
  *
  * @return 0 on success, otherwise a non-zero error code
  */

--- a/types.h
+++ b/types.h
@@ -414,7 +414,7 @@ typedef void (*JackClientRegistrationCallback)(const char* name, int register, v
 
 /**
  * Prototype for the client supplied function that is called 
- * whenever a client is registered or unregistered.
+ * whenever ports are connected or disconnected.
  *
  * @param a one of two ports connected or disconnected
  * @param b one of two ports connected or disconnected


### PR DESCRIPTION
Fixed invalid description of jack_set_port_rename_callback and JackPortConnectCallback in doxygen comments.
