### PR TITLE
Fix warnings and clean up public API headers

### DIFF
--- a/control.h
+++ b/control.h
@@ -1,24 +1,21 @@
-/* -*- Mode: C ; c-basic-offset: 4 -*- */
 /*
-  JACK control API
+    Copyright (C) 2008 Nedko Arnaudov
+    Copyright (C) 2008 GRAME
 
-  Copyright (C) 2008 Nedko Arnaudov
-  Copyright (C) 2008 GRAME
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; version 2 of the License.
 
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; version 2 of the License.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
+
 /**
  * @file   jack/control.h
  * @ingroup publicheader

--- a/control.h
+++ b/control.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __jack_control_h__
-#define __jack_control_h__
+#ifndef JACK_CONTROL_H
+#define JACK_CONTROL_H
 
 #include <jack/jslist.h>
 
@@ -559,4 +559,4 @@ jack_log(
 } /* extern "C" */
 #endif
 
-#endif /* __jack_control_h__ */
+#endif /* JACK_CONTROL_H */

--- a/control.h
+++ b/control.h
@@ -4,7 +4,7 @@
 
   Copyright (C) 2008 Nedko Arnaudov
   Copyright (C) 2008 GRAME
-    
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; version 2 of the License.
@@ -86,10 +86,10 @@ extern "C" {
  * @{
  */
 
-/** 
+/**
  * Call this function to setup process signal handling. As a general
  * rule, it is required for proper operation for the server object.
- * 
+ *
  * @param flags signals setup flags, use 0 for none. Currently no
  * flags are defined
  *
@@ -99,9 +99,9 @@ sigset_t
 jackctl_setup_signals(
     unsigned int flags);
 
-/** 
+/**
  * Call this function to wait on a signal set.
- * 
+ *
  * @param signals signals set to wait on
  */
 void
@@ -123,21 +123,21 @@ jackctl_server_create(
     bool (* on_device_acquire)(const char * device_name),
     void (* on_device_release)(const char * device_name));
 
-/** 
+/**
  * Call this function to destroy server object.
- * 
+ *
  * @param server server object handle to destroy
  */
 void
 jackctl_server_destroy(
 	jackctl_server_t * server);
 
-/** 
+/**
  * Call this function to start JACK server
- * 
+ *
  * @param server server object handle
  * @param driver driver to use
- * 
+ *
  * @return success status: true - success, false - fail
  */
 bool
@@ -145,21 +145,21 @@ jackctl_server_start(
     jackctl_server_t * server,
     jackctl_driver_t * driver);
 
-/** 
+/**
  * Call this function to stop JACK server
- * 
+ *
  * @param server server object handle
- * 
+ *
  * @return success status: true - success, false - fail
  */
 bool
 jackctl_server_stop(
 	jackctl_server_t * server);
 
-/** 
+/**
  * Call this function to get list of available drivers. List node data
  * pointers is a driver object handle (::jackctl_driver_t).
- * 
+ *
  * @param server server object handle to get drivers for
  *
  * @return Single linked list of driver object handles. Must not be
@@ -169,10 +169,10 @@ const JSList *
 jackctl_server_get_drivers_list(
 	jackctl_server_t * server);
 
-/** 
+/**
  * Call this function to get list of server parameters. List node data
  * pointers is a parameter object handle (::jackctl_parameter_t).
- * 
+ *
  * @param server server object handle to get parameters for
  *
  * @return Single linked list of parameter object handles. Must not be
@@ -182,10 +182,10 @@ const JSList *
 jackctl_server_get_parameters(
 	jackctl_server_t * server);
 
-/** 
+/**
  * Call this function to get list of available internal clients. List node data
  * pointers is a internal client object handle (::jackctl_internal_t).
- * 
+ *
  * @param server server object handle to get internal clients for
  *
  * @return Single linked list of internal client object handles. Must not be
@@ -195,12 +195,12 @@ const JSList *
 jackctl_server_get_internals_list(
 	jackctl_server_t * server);
 
-/** 
+/**
  * Call this function to load one internal client.
- * 
+ *
  * @param server server object handle
  * @param internal internal to use
- * 
+ *
  * @return success status: true - success, false - fail
  */
 bool
@@ -208,12 +208,12 @@ jackctl_server_load_internal(
     jackctl_server_t * server,
     jackctl_internal_t * internal);
 
-/** 
+/**
  * Call this function to unload one internal client.
- * 
+ *
  * @param server server object handle
  * @param internal internal to unload
- * 
+ *
  * @return success status: true - success, false - fail
  */
 bool
@@ -221,46 +221,46 @@ jackctl_server_unload_internal(
     jackctl_server_t * server,
     jackctl_internal_t * internal);
 
-/** 
+/**
  * Call this function to add a slave in the driver slave list.
- * 
+ *
  * @param server server object handle
  * @param driver driver to add in the driver slave list.
- * 
+ *
  * @return success status: true - success, false - fail
- */ 
-bool 
+ */
+bool
 jackctl_server_add_slave(jackctl_server_t * server,
                             jackctl_driver_t * driver);
 
-/** 
+/**
  * Call this function to remove a slave from the driver slave list.
- * 
+ *
  * @param server server object handle
  * @param driver driver to remove from the driver slave list.
- * 
+ *
  * @return success status: true - success, false - fail
- */ 
-bool 
+ */
+bool
 jackctl_server_remove_slave(jackctl_server_t * server,
                             jackctl_driver_t * driver);
 
-/** 
+/**
  * Call this function to switch master driver.
- * 
+ *
  * @param server server object handle
  * @param driver driver to switch to
- * 
+ *
  * @return success status: true - success, false - fail
- */                          
-bool 
+ */
+bool
 jackctl_server_switch_master(jackctl_server_t * server,
                             jackctl_driver_t * driver);
-                            
 
-/** 
+
+/**
  * Call this function to get name of driver.
- * 
+ *
  * @param driver driver object handle to get name of
  *
  * @return driver name. Must not be modified. Always same for same
@@ -270,10 +270,10 @@ const char *
 jackctl_driver_get_name(
 	jackctl_driver_t * driver);
 
-/** 
+/**
  * Call this function to get list of driver parameters. List node data
  * pointers is a parameter object handle (::jackctl_parameter_t).
- * 
+ *
  * @param driver driver object handle to get parameters for
  *
  * @return Single linked list of parameter object handles. Must not be
@@ -283,9 +283,9 @@ const JSList *
 jackctl_driver_get_parameters(
 	jackctl_driver_t * driver);
 
-/** 
+/**
  * Call this function to get name of internal client.
- * 
+ *
  * @param internal internal object handle to get name of
  *
  * @return internal name. Must not be modified. Always same for same
@@ -295,10 +295,10 @@ const char *
 jackctl_internal_get_name(
 	jackctl_internal_t * internal);
 
-/** 
+/**
  * Call this function to get list of internal parameters. List node data
  * pointers is a parameter object handle (::jackctl_parameter_t).
- * 
+ *
  * @param internal internal object handle to get parameters for
  *
  * @return Single linked list of parameter object handles. Must not be
@@ -308,9 +308,9 @@ const JSList *
 jackctl_internal_get_parameters(
 	jackctl_internal_t * internal);
 
-/** 
+/**
  * Call this function to get parameter name.
- * 
+ *
  * @param parameter parameter object handle to get name of
  *
  * @return parameter name. Must not be modified. Always same for same
@@ -320,9 +320,9 @@ const char *
 jackctl_parameter_get_name(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to get parameter short description.
- * 
+ *
  * @param parameter parameter object handle to get short description of
  *
  * @return parameter short description. Must not be modified. Always
@@ -332,9 +332,9 @@ const char *
 jackctl_parameter_get_short_description(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to get parameter long description.
- * 
+ *
  * @param parameter parameter object handle to get long description of
  *
  * @return parameter long description. Must not be modified. Always
@@ -344,9 +344,9 @@ const char *
 jackctl_parameter_get_long_description(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to get parameter type.
- * 
+ *
  * @param parameter parameter object handle to get type of
  *
  * @return parameter type. Always same for same parameter object.
@@ -355,21 +355,21 @@ jackctl_param_type_t
 jackctl_parameter_get_type(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to get parameter character.
- * 
+ *
  * @param parameter parameter object handle to get character of
  *
- * @return character. 
+ * @return character.
  */
 char
 jackctl_parameter_get_id(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to check whether parameter has been set, or its
  * default value is being used.
- * 
+ *
  * @param parameter parameter object handle to check
  *
  * @return true - parameter is set, false - parameter is using default
@@ -379,9 +379,9 @@ bool
 jackctl_parameter_is_set(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to reset parameter to its default value.
- * 
+ *
  * @param parameter parameter object handle to reset value of
  *
  * @return success status: true - success, false - fail
@@ -390,9 +390,9 @@ bool
 jackctl_parameter_reset(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to get parameter value.
- * 
+ *
  * @param parameter parameter object handle to get value of
  *
  * @return parameter value.
@@ -401,9 +401,9 @@ union jackctl_parameter_value
 jackctl_parameter_get_value(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to set parameter value.
- * 
+ *
  * @param parameter parameter object handle to get value of
  * @param value_ptr pointer to variable containing parameter value
  *
@@ -414,9 +414,9 @@ jackctl_parameter_set_value(
 	jackctl_parameter_t * parameter,
 	const union jackctl_parameter_value * value_ptr);
 
-/** 
+/**
  * Call this function to get parameter default value.
- * 
+ *
  * @param parameter parameter object handle to get default value of
  *
  * @return parameter default value.
@@ -424,10 +424,10 @@ jackctl_parameter_set_value(
 union jackctl_parameter_value
 jackctl_parameter_get_default_value(
 	jackctl_parameter_t * parameter);
-    
-/** 
+
+/**
  * Call this function check whether parameter has range constraint.
- * 
+ *
  * @param parameter object handle of parameter to check
  *
  * @return whether parameter has range constraint.
@@ -436,9 +436,9 @@ bool
 jackctl_parameter_has_range_constraint(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function check whether parameter has enumeration constraint.
- * 
+ *
  * @param parameter object handle of parameter to check
  *
  * @return whether parameter has enumeration constraint.
@@ -447,9 +447,9 @@ bool
 jackctl_parameter_has_enum_constraint(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function get how many enumeration values parameter has.
- * 
+ *
  * @param parameter object handle of parameter
  *
  * @return number of enumeration values
@@ -458,9 +458,9 @@ uint32_t
 jackctl_parameter_get_enum_constraints_count(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to get parameter enumeration value.
- * 
+ *
  * @param parameter object handle of parameter
  * @param index index of parameter enumeration value
  *
@@ -471,9 +471,9 @@ jackctl_parameter_get_enum_constraint_value(
 	jackctl_parameter_t * parameter,
 	uint32_t index);
 
-/** 
+/**
  * Call this function to get parameter enumeration value description.
- * 
+ *
  * @param parameter object handle of parameter
  * @param index index of parameter enumeration value
  *
@@ -484,9 +484,9 @@ jackctl_parameter_get_enum_constraint_description(
 	jackctl_parameter_t * parameter,
 	uint32_t index);
 
-/** 
+/**
  * Call this function to get parameter range.
- * 
+ *
  * @param parameter object handle of parameter
  * @param min_ptr pointer to variable receiving parameter minimum value
  * @param max_ptr pointer to variable receiving parameter maximum value
@@ -497,10 +497,10 @@ jackctl_parameter_get_range_constraint(
 	union jackctl_parameter_value * min_ptr,
 	union jackctl_parameter_value * max_ptr);
 
-/** 
+/**
  * Call this function to check whether parameter constraint is strict,
  * i.e. whether supplying non-matching value will not work for sure.
- * 
+ *
  * @param parameter parameter object handle to check
  *
  * @return whether parameter constraint is strict.
@@ -509,11 +509,11 @@ bool
 jackctl_parameter_constraint_is_strict(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to check whether parameter has fake values,
  * i.e. values have no user meaningful meaning and only value
  * description is meaningful to user.
- * 
+ *
  * @param parameter parameter object handle to check
  *
  * @return whether parameter constraint is strict.
@@ -522,9 +522,9 @@ bool
 jackctl_parameter_constraint_is_fake_value(
 	jackctl_parameter_t * parameter);
 
-/** 
+/**
  * Call this function to log an error message.
- * 
+ *
  * @param format string
  */
 void
@@ -532,9 +532,9 @@ jack_error(
 	const char *format,
 	...);
 
-/** 
+/**
  * Call this function to log an information message.
- * 
+ *
  * @param format string
  */
 void
@@ -542,10 +542,10 @@ jack_info(
 	const char *format,
 	...);
 
-/** 
+/**
  * Call this function to log an information message but only when
  * verbose mode is enabled.
- * 
+ *
  * @param format string
  */
 void

--- a/intclient.h
+++ b/intclient.h
@@ -92,9 +92,6 @@ int jack_internal_client_handle (jack_client_t *client,
  * information from the load operation.  This status word is formed by
  * OR-ing together the relevant @ref JackStatus bits.
  *
- * @param handle the client handle will be returned here (passed
- * by reference because of the type.
- *
  * <b>Optional parameters:</b> depending on corresponding [@a options
  * bits] additional parameters may follow @a status (in this order).
  *

--- a/intclient.h
+++ b/intclient.h
@@ -1,18 +1,18 @@
 /*
  *  Copyright (C) 2004 Jack O'Quin
- *  
+ *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation; either version 2.1 of the License, or
  *  (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU Lesser General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software 
+ *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *
  */
@@ -114,7 +114,7 @@ int jack_internal_client_handle (jack_client_t *client,
 int jack_internal_client_load (jack_client_t *client,
                                const char *client_name,
                                jack_options_t options,
-                               jack_status_t *status, 
+                               jack_status_t *status,
                                jack_intclient_t, ...);
 /**
  * Unload an internal client from a JACK server.  This calls the

--- a/intclient.h
+++ b/intclient.h
@@ -1,21 +1,20 @@
 /*
- *  Copyright (C) 2004 Jack O'Quin
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU Lesser General Public License as published by
- *  the Free Software Foundation; either version 2.1 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- *
- */
+    Copyright (C) 2004 Jack O'Quin
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*/
 
 #ifndef __jack_intclient_h__
 #define __jack_intclient_h__

--- a/intclient.h
+++ b/intclient.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_intclient_h__
-#define __jack_intclient_h__
+#ifndef JACK_INTCLIENT_H
+#define JACK_INTCLIENT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -134,4 +134,4 @@ jack_status_t jack_internal_client_unload (jack_client_t *client,
 }
 #endif
 
-#endif /* __jack_intclient_h__ */
+#endif /* JACK_INTCLIENT_H */

--- a/jack.h
+++ b/jack.h
@@ -15,7 +15,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef __jack_h__

--- a/jack.h
+++ b/jack.h
@@ -1,19 +1,19 @@
 /*
     Copyright (C) 2001 Paul Davis
     Copyright (C) 2004 Jack O'Quin
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -37,12 +37,12 @@ extern "C" {
 /*************************************************************
  * NOTE: JACK_WEAK_EXPORT ***MUST*** be used on every function
  * added to the JACK API after the 0.116.2 release.
- * 
- * Functions that predate this release are marked with 
+ *
+ * Functions that predate this release are marked with
  * JACK_WEAK_OPTIONAL_EXPORT which can be defined at compile
  * time in a variety of ways. The default definition is empty,
  * so that these symbols get normal linkage. If you wish to
- * use all JACK symbols with weak linkage, include 
+ * use all JACK symbols with weak linkage, include
  * <jack/weakjack.h> before jack.h.
  *************************************************************/
 
@@ -137,7 +137,7 @@ char *jack_get_uuid_for_client_name (jack_client_t *client,
  *
  * @param client making the request
  * @param uuid   the uuid of the client whose name is desired
- * 
+ *
  * Return NULL if no such client with the given UUID exists
  */
 char *jack_get_client_name_by_uuid (jack_client_t *client,
@@ -225,21 +225,21 @@ jack_nframes_t jack_thread_wait (jack_client_t*, int status) JACK_OPTIONAL_WEAK_
 
 /**
  * Wait until this JACK client should process data.
- * 
+ *
  * @param client - pointer to a JACK client structure
  *
  * @return the number of frames of data to process
  */
 jack_nframes_t jack_cycle_wait (jack_client_t* client) JACK_OPTIONAL_WEAK_EXPORT;
-	
+
 /**
  * Signal next clients in the graph.
- * 
+ *
  * @param client - pointer to a JACK client structure
  * @param status - if non-zero, calling thread should exit
  */
 void jack_cycle_signal (jack_client_t* client, int status) JACK_OPTIONAL_WEAK_EXPORT;
-	
+
 /**
  * Tell the Jack server to call @a thread_callback in the RT thread.
  * Typical use are in conjunction with @a jack_cycle_wait and @ jack_cycle_signal functions.
@@ -247,10 +247,10 @@ void jack_cycle_signal (jack_client_t* client, int status) JACK_OPTIONAL_WEAK_EX
  * execution. That means that it cannot call functions that might
  * block for a long time. This includes all I/O functions (disk, TTY, network),
  * malloc, free, printf, pthread_mutex_lock, sleep, wait, poll, select, pthread_join,
- * pthread_cond_wait, etc, etc. 
+ * pthread_cond_wait, etc, etc.
  *
  * @return 0 on success, otherwise a non-zero error code.
-*/    
+*/
 int jack_set_process_thread(jack_client_t* client, JackThreadCallback fun, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
 
 /*@}*/
@@ -262,7 +262,7 @@ int jack_set_process_thread(jack_client_t* client, JackThreadCallback fun, void 
 
 /**
  * Tell JACK to call @a thread_init_callback once just after
- * the creation of the thread in which all other callbacks 
+ * the creation of the thread in which all other callbacks
  * will be handled.
  *
  * The code in the supplied function does not need to be
@@ -275,7 +275,7 @@ int jack_set_thread_init_callback (jack_client_t *client,
 				   JackThreadInitCallback thread_init_callback,
 				   void *arg) JACK_OPTIONAL_WEAK_EXPORT;
 
-/** 
+/**
  * @param client pointer to JACK client structure.
  * @param function The jack_shutdown function pointer.
  * @param arg The arguments for the jack_shutdown function.
@@ -292,9 +292,9 @@ int jack_set_thread_init_callback (jack_client_t *client,
  * NOTE: clients do not need to call this.  It exists only
  * to help more complex clients understand what is going
  * on.  It should be called before jack_client_activate().
- * 
+ *
  * NOTE: if a client calls this AND jack_on_info_shutdown(), then
- * the event of a client thread shutdown, the callback 
+ * the event of a client thread shutdown, the callback
  * passed to this function will not be called, and the one passed to
  * jack_on_info_shutdown() will.
  */
@@ -320,7 +320,7 @@ void jack_on_shutdown (jack_client_t *client,
  * on.  It should be called before jack_client_activate().
  *
  * NOTE: if a client calls this AND jack_on_shutdown(), then in the
- * event of a client thread shutdown, the callback   passed to 
+ * event of a client thread shutdown, the callback   passed to
  * this function will be called, and the one passed to
  * jack_on_shutdown() will not.
  */
@@ -335,7 +335,7 @@ void jack_on_info_shutdown (jack_client_t *client,
  * execution. That means that it cannot call functions that might
  * block for a long time. This includes all I/O functions (disk, TTY, network),
  * malloc, free, printf, pthread_mutex_lock, sleep, wait, poll, select, pthread_join,
- * pthread_cond_wait, etc, etc. 
+ * pthread_cond_wait, etc, etc.
  *
  * @return 0 on success, otherwise a non-zero error code, causing JACK
  * to remove that client from the process() graph.
@@ -392,7 +392,7 @@ int jack_set_sample_rate_callback (jack_client_t *client,
 int jack_set_client_registration_callback (jack_client_t *,
 					   JackClientRegistrationCallback
 					   registration_callback, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
-	
+
 /**
  * Tell the JACK server to call @a registration_callback whenever a
  * port is registered or unregistered, passing @a arg as a parameter.
@@ -462,37 +462,37 @@ int jack_set_xrun_callback (jack_client_t *,
  *    - have only output ports
  *    - their output is totally unrelated to their input
  *    - their output is not delayed relative to their input
- *        (i.e. data that arrives in a given process() 
+ *        (i.e. data that arrives in a given process()
  *         callback is processed and output again in the
  *         same callback)
  *
  * Clients NOT registering a latency callback MUST also
  * satisfy this condition:
- * 
+ *
  *    - have no multiple distinct internal signal pathways
- *      
+ *
  * This means that if your client has more than 1 input and
  * output port, and considers them always "correlated"
  * (e.g. as a stereo pair), then there is only 1 (e.g. stereo)
  * signal pathway through the client. This would be true,
  * for example, of a stereo FX rack client that has a
  * left/right input pair and a left/right output pair.
- * 
+ *
  * However, this is somewhat a matter of perspective. The
- * same FX rack client could be connected so that its 
+ * same FX rack client could be connected so that its
  * two input ports were connected to entirely separate
  * sources. Under these conditions, the fact that the client
  * does not register a latency callback MAY result
- * in port latency values being incorrect. 
+ * in port latency values being incorrect.
  *
  * Clients that do not meet any of those conditions SHOULD
- * register a latency callback. 
+ * register a latency callback.
  *
  * Another case is when a client wants to use
  * @ref jack_port_get_latency_range(), which only returns meaninful
  * values when ports get connected and latency values change.
  *
- * See the documentation for  @ref jack_port_set_latency_range() 
+ * See the documentation for  @ref jack_port_set_latency_range()
  * on how the callback should operate. Remember that the @a mode
  * argument given to the latency callback will need to be
  * passed into @ref jack_port_set_latency_range()
@@ -514,19 +514,19 @@ int jack_set_latency_callback (jack_client_t *,
  *
  * When in "freewheel" mode, JACK no longer waits for
  * any external event to begin the start of the next process
- * cycle. 
+ * cycle.
  *
  * As a result, freewheel mode causes "faster than realtime"
  * execution of a JACK graph. If possessed, real-time
  * scheduling is dropped when entering freewheel mode, and
  * if appropriate it is reacquired when stopping.
- * 
+ *
  * IMPORTANT: on systems using capabilities to provide real-time
  * scheduling (i.e. Linux kernel 2.4), if onoff is zero, this function
- * must be called from the thread that originally called jack_activate(). 
- * This restriction does not apply to other systems (e.g. Linux kernel 2.6 
+ * must be called from the thread that originally called jack_activate().
+ * This restriction does not apply to other systems (e.g. Linux kernel 2.6
  * or OS X).
- * 
+ *
  * @param client pointer to JACK client structure
  * @param onoff  if non-zero, freewheel mode starts. Otherwise
  *                  freewheel mode ends.
@@ -588,7 +588,7 @@ int  jack_engine_takeover_timebase (jack_client_t *) JACK_OPTIONAL_WEAK_DEPRECAT
  * determined by the buffer size and sample rate.
  */
 float jack_cpu_load (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
-	
+
 
 /*@}*/
 
@@ -608,8 +608,8 @@ float jack_cpu_load (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  * name.  Exceeding that will cause the port registration to fail and
  * return NULL.
  *
- * The @a port_name must be unique among all ports owned by this client. 
- * If the name is not unique, the registration will fail. 
+ * The @a port_name must be unique among all ports owned by this client.
+ * If the name is not unique, the registration will fail.
  *
  * All ports have a type, which may be any non-NULL and non-zero
  * length string, passed as an argument.  Some port types are built
@@ -632,7 +632,7 @@ jack_port_t *jack_port_register (jack_client_t *client,
                                  unsigned long flags,
                                  unsigned long buffer_size) JACK_OPTIONAL_WEAK_EXPORT;
 
-/** 
+/**
  * Remove the port from the client, disconnecting any existing
  * connections.
  *
@@ -646,7 +646,7 @@ int jack_port_unregister (jack_client_t *, jack_port_t *) JACK_OPTIONAL_WEAK_EXP
  * that can be written to; for an input port, it will be an area
  * containing the data from the port's connection(s), or
  * zero-filled. if there are multiple inbound connections, the data
- * will be mixed appropriately.  
+ * will be mixed appropriately.
  *
  * Do not cache the returned address across process() callbacks.
  * Port buffers have to be retrieved in each callback for proper functionning.
@@ -687,12 +687,12 @@ int jack_port_flags (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
  */
 const char *jack_port_type (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
-/** 
+/**
  * @return TRUE if the jack_port_t belongs to the jack_client_t.
  */
 int jack_port_is_mine (const jack_client_t *, const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
-/** 
+/**
  * @return number of connections to or from @a port.
  *
  * @pre The calling client must own @a port.
@@ -718,7 +718,7 @@ int jack_port_connected_to (const jack_port_t *port,
  * @param port locally owned jack_port_t pointer.
  *
  * @see jack_port_name_size(), jack_port_get_all_connections()
- */   
+ */
 const char **jack_port_get_connections (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -736,17 +736,17 @@ const char **jack_port_get_connections (const jack_port_t *port) JACK_OPTIONAL_W
  *          you cannot use it in a GraphReordered handler.
  *
  *     2) You need not be the owner of the port to get information
- *          about its connections. 
+ *          about its connections.
  *
  * @see jack_port_name_size()
- */   
+ */
 const char **jack_port_get_all_connections (const jack_client_t *client,
 					    const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  *
- * @deprecated This function will be removed from a future version 
- * of JACK. Do not use it. There is no replacement. It has 
+ * @deprecated This function will be removed from a future version
+ * of JACK. Do not use it. There is no replacement. It has
  * turned out to serve essentially no purpose in real-life
  * JACK clients.
  */
@@ -754,8 +754,8 @@ int  jack_port_tie (jack_port_t *src, jack_port_t *dst) JACK_OPTIONAL_WEAK_DEPRE
 
 /**
  *
- * @deprecated This function will be removed from a future version 
- * of JACK. Do not use it. There is no replacement. It has 
+ * @deprecated This function will be removed from a future version
+ * of JACK. Do not use it. There is no replacement. It has
  * turned out to serve essentially no purpose in real-life
  * JACK clients.
  */
@@ -771,26 +771,26 @@ int  jack_port_untie (jack_port_t *port) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 int jack_port_set_name (jack_port_t *port, const char *port_name) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
- * Modify a port's short name.  May NOT be called from a callback handling a server event.  
+ * Modify a port's short name.  May NOT be called from a callback handling a server event.
  * If the resulting full name (including the @a "client_name:" prefix) is
  * longer than jack_port_name_size(), it will be truncated.
  *
  * @return 0 on success, otherwise a non-zero error code.
  *
- * This differs from jack_port_set_name() by triggering PortRename notifications to 
+ * This differs from jack_port_set_name() by triggering PortRename notifications to
  * clients that have registered a port rename handler.
  */
 int jack_port_rename (jack_client_t* client, jack_port_t *port, const char *port_name) JACK_OPTIONAL_WEAK_EXPORT;
-	
+
 /**
  * Set @a alias as an alias for @a port.  May be called at any time.
  * If the alias is longer than jack_port_name_size(), it will be truncated.
- * 
+ *
  * After a successful call, and until JACK exits or
  * jack_port_unset_alias() is called, may be
  * used as a alternate name for the port.
  *
- * Ports can have up to two aliases - if both are already 
+ * Ports can have up to two aliases - if both are already
  * set, this function will return an error.
  *
  * @return 0 on success, otherwise a non-zero error code.
@@ -799,8 +799,8 @@ int jack_port_set_alias (jack_port_t *port, const char *alias) JACK_OPTIONAL_WEA
 
 /**
  * Remove @a alias as an alias for @a port.  May be called at any time.
- * 
- * After a successful call, @a alias can no longer be 
+ *
+ * After a successful call, @a alias can no longer be
  * used as a alternate name for the port.
  *
  * @return 0 on success, otherwise a non-zero error code.
@@ -924,7 +924,7 @@ size_t jack_port_type_get_buffer_size (jack_client_t *client, const char *port_t
  *
  * The purpose of JACK's latency API is to allow clients to
  * easily answer two questions:
- * 
+ *
  * - How long has it been since the data read from a port arrived
  *   at the edge of the JACK graph (either via a physical port
  *   or being synthesized from scratch)?
@@ -932,9 +932,9 @@ size_t jack_port_type_get_buffer_size (jack_client_t *client, const char *port_t
  * - How long will it be before the data written to a port arrives
  *   at the edge of a JACK graph?
 
- * To help answering these two questions, all JACK ports have two 
+ * To help answering these two questions, all JACK ports have two
  * latency values associated with them, both measured in frames:
- * 
+ *
  * <b>capture latency</b>: how long since the data read from
  *                  the buffer of a port arrived at at
  *                  a port marked with JackPortIsTerminal.
@@ -943,15 +943,15 @@ size_t jack_port_type_get_buffer_size (jack_client_t *client, const char *port_t
  *                  marked with JackPortIsPhysical, or
  *                  will have been synthesized by the client
  *                  that owns the terminal port.
- *                  
+ *
  * <b>playback latency</b>: how long until the data
  *                   written to the buffer of port will reach a port
  *                   marked with JackPortIsTerminal.
- * 
+ *
  * Both latencies might potentially have more than one value
  * because there may be multiple pathways to/from a given port
  * and a terminal port. Latency is therefore generally
- * expressed a min/max pair. 
+ * expressed a min/max pair.
  *
  * In most common setups, the minimum and maximum latency
  * are the same, but this design accomodates more complex
@@ -963,7 +963,7 @@ size_t jack_port_type_get_buffer_size (jack_client_t *client, const char *port_t
  *
  * See also @ref jack_set_latency_callback for details on how
  * clients that add latency to the signal path should interact
- * with JACK to ensure that the correct latency figures are 
+ * with JACK to ensure that the correct latency figures are
  * used.
  * @{
  */
@@ -976,7 +976,7 @@ size_t jack_port_type_get_buffer_size (jack_client_t *client, const char *port_t
  * physical hardware controlled by the client. For example,
  * for a client controlling a digital audio interface connected
  * to an external digital converter, the latency setting should
- * include both buffering by the audio interface *and* the converter. 
+ * include both buffering by the audio interface *and* the converter.
  *
  * @deprecated This method will be removed in the next major
  * release of JACK. It should not be used in new code, and should
@@ -984,11 +984,11 @@ size_t jack_port_type_get_buffer_size (jack_client_t *client, const char *port_t
  * jack_port_set_latency_range().
  */
 void jack_port_set_latency (jack_port_t *, jack_nframes_t) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
-	
+
 /**
- * return the latency range defined by @a mode for 
+ * return the latency range defined by @a mode for
  * @a port, in frames.
- *  
+ *
  * See @ref LatencyFunctions for the definition of each latency value.
  *
  * This function is best used from callbacks, specifically the latency callback.
@@ -1000,9 +1000,9 @@ void jack_port_set_latency (jack_port_t *, jack_nframes_t) JACK_OPTIONAL_WEAK_DE
 void jack_port_get_latency_range (jack_port_t *port, jack_latency_callback_mode_t mode, jack_latency_range_t *range) JACK_WEAK_EXPORT;
 
 /**
- * set the minimum and maximum latencies defined by 
+ * set the minimum and maximum latencies defined by
  * @a mode for @a port, in frames.
- *  
+ *
  * See @ref LatencyFunctions for the definition of each latency value.
  *
  * This function should ONLY be used inside a latency
@@ -1010,8 +1010,8 @@ void jack_port_get_latency_range (jack_port_t *port, jack_latency_callback_mode_
  * value of the latency using @ref jack_port_get_latency_range()
  * (called using the same mode as @a mode)
  * and then add some number of frames to that reflects
- * latency added by the client. 
- * 
+ * latency added by the client.
+ *
  * How much latency a client adds will vary
  * dramatically. For most clients, the answer is zero
  * and there is no reason for them to register a latency
@@ -1024,7 +1024,7 @@ void jack_port_get_latency_range (jack_port_t *port, jack_latency_callback_mode_
  * generally know a single constant value to add
  * to the value returned by @ref jack_port_get_latency_range().
  *
- * Such clients would register a latency callback (see 
+ * Such clients would register a latency callback (see
  * @ref jack_set_latency_callback) and must know what input
  * ports feed which output ports as part of their
  * internal state. Their latency callback will update
@@ -1032,9 +1032,9 @@ void jack_port_get_latency_range (jack_port_t *port, jack_latency_callback_mode_
  *
  * A pseudo-code example will help. The @a mode argument to the latency
  * callback will determine whether playback or capture
- * latency is being set. The callback will use 
+ * latency is being set. The callback will use
  * @ref jack_port_set_latency_range() as follows:
- * 
+ *
  * \code
  * jack_latency_range_t range;
  * if (mode == JackPlaybackLatency) {
@@ -1045,7 +1045,7 @@ void jack_port_get_latency_range (jack_port_t *port, jack_latency_callback_mode_
  *   jack_port_set_latency_range (input_port, JackPlaybackLatency, &range);
  *  }
  * } else if (mode == JackCaptureLatency) {
- *  foreach output_port in (all self-registered port) { 
+ *  foreach output_port in (all self-registered port) {
  *   jack_port_get_latency_range (port_fed_by_output_port, JackCaptureLatency, &range);
  *   range.min += min_delay_added_as_signal_flows_from_output_port_to_fed_by_port;
  *   range.max += max_delay_added_as_signal_flows_from_output_port_to_fed_by_port;
@@ -1058,12 +1058,12 @@ void jack_port_get_latency_range (jack_port_t *port, jack_latency_callback_mode_
  * each input port or output is connected to only 1 output or input
  * port respectively.
  *
- * If a port is connected to more than 1 other port, then the 
+ * If a port is connected to more than 1 other port, then the
  * range.min and range.max values passed to @ref
  * jack_port_set_latency_range() should reflect the minimum and
  * maximum values across all connected ports.
  *
- * See the description of @ref jack_set_latency_callback for more 
+ * See the description of @ref jack_set_latency_callback for more
  * information.
  */
 void jack_port_set_latency_range (jack_port_t *port, jack_latency_callback_mode_t mode, jack_latency_range_t *range) JACK_WEAK_EXPORT;
@@ -1074,16 +1074,16 @@ void jack_port_set_latency_range (jack_port_t *port, jack_latency_callback_mode_
  * latency of its port using  jack_port_set_latency
  * and wants to ensure that all signal pathways in the graph
  * are updated with respect to the values that will be returned
- * by  jack_port_get_total_latency. It allows a client 
- * to change multiple port latencies without triggering a 
+ * by  jack_port_get_total_latency. It allows a client
+ * to change multiple port latencies without triggering a
  * recompute for each change.
- * 
+ *
  * @return zero for successful execution of the request. non-zero
  *         otherwise.
  */
 int jack_recompute_total_latencies (jack_client_t*) JACK_OPTIONAL_WEAK_EXPORT;
 
-/** 
+/**
  * @return the time (in frames) between data being available or
  * delivered at/to a port, and the time at which it arrived at or is
  * delivered to the "other side" of the port.  E.g. for a physical
@@ -1095,7 +1095,7 @@ int jack_recompute_total_latencies (jack_client_t*) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @deprecated This method will be removed in the next major
  * release of JACK. It should not be used in new code, and should
- * be replaced by jack_port_get_latency_range() in any existing 
+ * be replaced by jack_port_get_latency_range() in any existing
  * use cases.
  */
 jack_nframes_t jack_port_get_latency (jack_port_t *port) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
@@ -1107,7 +1107,7 @@ jack_nframes_t jack_port_get_latency (jack_port_t *port) JACK_OPTIONAL_WEAK_DEPR
  *
  * @deprecated This method will be removed in the next major
  * release of JACK. It should not be used in new code, and should
- * be replaced by jack_port_get_latency_range() in any existing 
+ * be replaced by jack_port_get_latency_range() in any existing
  * use cases.
  */
 jack_nframes_t jack_port_get_total_latency (jack_client_t *,
@@ -1119,8 +1119,8 @@ jack_nframes_t jack_port_get_total_latency (jack_client_t *,
  * latency of its port using  jack_port_set_latency
  * and wants to ensure that all signal pathways in the graph
  * are updated with respect to the values that will be returned
- * by  jack_port_get_total_latency. 
- * 
+ * by  jack_port_get_total_latency.
+ *
  * @return zero for successful execution of the request. non-zero
  *         otherwise.
  *
@@ -1139,13 +1139,13 @@ int jack_recompute_total_latency (jack_client_t*, jack_port_t* port) JACK_OPTION
  */
 
 /**
- * @param port_name_pattern A regular expression used to select 
- * ports by name.  If NULL or of zero length, no selection based 
+ * @param port_name_pattern A regular expression used to select
+ * ports by name.  If NULL or of zero length, no selection based
  * on name will be carried out.
- * @param type_name_pattern A regular expression used to select 
- * ports by type.  If NULL or of zero length, no selection based 
+ * @param type_name_pattern A regular expression used to select
+ * ports by type.  If NULL or of zero length, no selection based
  * on type will be carried out.
- * @param flags A value used to select ports by their flags.  
+ * @param flags A value used to select ports by their flags.
  * If zero, no selection based on flags will be carried out.
  *
  * @return a NULL-terminated array of ports that match the specified
@@ -1154,9 +1154,9 @@ int jack_recompute_total_latency (jack_client_t*, jack_port_t* port) JACK_OPTION
  *
  * @see jack_port_name_size(), jack_port_type_size()
  */
-const char **jack_get_ports (jack_client_t *, 
-			     const char *port_name_pattern, 
-			     const char *type_name_pattern, 
+const char **jack_get_ports (jack_client_t *,
+			     const char *port_name_pattern,
+			     const char *type_name_pattern,
 			     unsigned long flags) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1203,7 +1203,7 @@ jack_nframes_t jack_frame_time (const jack_client_t *) JACK_OPTIONAL_WEAK_EXPORT
  * This function may only be used from the process callback, and can
  * be used to interpret timestamps generated by jack_frame_time() in
  * other threads with respect to the current process cycle.
- * 
+ *
  * This is the only jack time function that returns exact time:
  * when used during the process callback it always returns the same
  * value (until the next process callback, where it will return
@@ -1236,14 +1236,14 @@ jack_nframes_t jack_last_frame_time (const jack_client_t *client) JACK_OPTIONAL_
  *                  microseconds.
  *
  * NOTES:
- * 
+ *
  * Because of the types used, all the returned values except period_usecs
  * are unsigned. In computations mapping between frames and microseconds
  * *signed* differences are required. The easiest way is to compute those
  * separately and assign them to the appropriate signed variables,
  * int32_t for frames and int64_t for usecs. See the implementation of
  * jack_frames_to_time() and Jack_time_to_frames() for an example.
- * 
+ *
  * Unless there was an xrun, skipped cycles, or the current cycle is the
  * first after freewheeling or starting Jack, the value of current_usecs
  * will always be the value of next_usecs of the previous cycle.
@@ -1275,8 +1275,8 @@ jack_nframes_t jack_time_to_frames(const jack_client_t *client, jack_time_t) JAC
 
 /**
  * @return return JACK's current system time in microseconds,
- *         using the JACK clock source. 
- * 
+ *         using the JACK clock source.
+ *
  * The value returned is guaranteed to be monotonic, but not linear.
  */
 jack_time_t jack_get_time(void) JACK_OPTIONAL_WEAK_EXPORT;
@@ -1323,7 +1323,7 @@ void jack_set_info_function (void (*func)(const char *)) JACK_OPTIONAL_WEAK_EXPO
 /*@}*/
 
 /**
- * The free function to be used on memory returned by jack_port_get_connections, 
+ * The free function to be used on memory returned by jack_port_get_connections,
  * jack_port_get_all_connections and jack_get_ports functions.
  * This is MANDATORY on Windows when otherwise all nasty runtime version related crashes can occur.
  * Developers are strongly encouraged to use this function instead of the standard "free" function in new code.

--- a/jack.h
+++ b/jack.h
@@ -119,7 +119,7 @@ char *jack_get_client_name (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return pointer to a string representation of the UUID for
- * a client named @param name . If no such client exists, return NULL
+ * a client named `name`. If no such client exists, return NULL
  *
  * @param client the client making the request
  * @param name   the name of the client whose UUID is desired
@@ -807,7 +807,7 @@ int jack_port_set_alias (jack_port_t *port, const char *alias) JACK_OPTIONAL_WEA
 int jack_port_unset_alias (jack_port_t *port, const char *alias) JACK_OPTIONAL_WEAK_EXPORT;
 
 /*
- * Get any aliases known for @port.
+ * Get any aliases known for `port`.
  *
  * @return the number of aliases discovered for the port
  */

--- a/jack.h
+++ b/jack.h
@@ -17,8 +17,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_h__
-#define __jack_h__
+#ifndef JACK_JACK_H
+#define JACK_JACK_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -1334,4 +1334,4 @@ void jack_free(void* ptr) JACK_OPTIONAL_WEAK_EXPORT;
 }
 #endif
 
-#endif /* __jack_h__ */
+#endif /* JACK_JACK_H */

--- a/jslist.h
+++ b/jslist.h
@@ -19,7 +19,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef __jack_jslist_h__

--- a/jslist.h
+++ b/jslist.h
@@ -1,6 +1,6 @@
 /*
     Based on gslist.c from glib-1.2.9 (LGPL).
- 
+
     Adaption to JACK, Copyright (C) 2002 Kai Vehmanen.
       - replaced use of gtypes with normal ANSI C types
       - glib's memery allocation routines replaced with
@@ -10,14 +10,14 @@
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -50,7 +50,7 @@ jack_slist_alloc (void)
   return new_list;
 }
 
-static __inline__ 
+static __inline__
 JSList*
 jack_slist_prepend (JSList   *list,
 		    void     *data)
@@ -65,7 +65,7 @@ jack_slist_prepend (JSList   *list,
 }
 
 #define jack_slist_next(slist)	((slist) ? (((JSList *)(slist))->next) : NULL)
-static __inline__ 
+static __inline__
 JSList*
 jack_slist_last (JSList *list)
 {
@@ -78,7 +78,7 @@ jack_slist_last (JSList *list)
   return list;
 }
 
-static __inline__ 
+static __inline__
 JSList*
 jack_slist_remove_link (JSList *list,
 		     JSList *link)
@@ -109,7 +109,7 @@ jack_slist_remove_link (JSList *list,
   return list;
 }
 
-static __inline__ 
+static __inline__
 void
 jack_slist_free (JSList *list)
 {
@@ -121,7 +121,7 @@ jack_slist_free (JSList *list)
     }
 }
 
-static __inline__ 
+static __inline__
 void
 jack_slist_free_1 (JSList *list)
 {
@@ -131,7 +131,7 @@ jack_slist_free_1 (JSList *list)
     }
 }
 
-static __inline__ 
+static __inline__
 JSList*
 jack_slist_remove (JSList   *list,
 		   void     *data)
@@ -164,7 +164,7 @@ jack_slist_remove (JSList   *list,
   return list;
 }
 
-static __inline__ 
+static __inline__
 unsigned int
 jack_slist_length (JSList *list)
 {
@@ -180,7 +180,7 @@ jack_slist_length (JSList *list)
   return length;
 }
 
-static __inline__ 
+static __inline__
 JSList*
 jack_slist_find (JSList   *list,
 		 void     *data)
@@ -195,7 +195,7 @@ jack_slist_find (JSList   *list,
   return list;
 }
 
-static __inline__ 
+static __inline__
 JSList*
 jack_slist_copy (JSList *list)
 {
@@ -221,7 +221,7 @@ jack_slist_copy (JSList *list)
   return new_list;
 }
 
-static __inline__ 
+static __inline__
 JSList*
 jack_slist_append (JSList   *list,
 		   void     *data)
@@ -243,9 +243,9 @@ jack_slist_append (JSList   *list,
       return new_list;
 }
 
-static __inline__ 
-JSList* 
-jack_slist_sort_merge  (JSList      *l1, 
+static __inline__
+JSList*
+jack_slist_sort_merge  (JSList      *l1,
 			JSList      *l2,
 			JCompareFunc compare_func)
 {
@@ -259,40 +259,40 @@ jack_slist_sort_merge  (JSList      *l1,
         {
 	  l=l->next=l1;
 	  l1=l1->next;
-        } 
-      else 
+        }
+      else
 	{
 	  l=l->next=l2;
 	  l2=l2->next;
         }
     }
   l->next= l1 ? l1 : l2;
-  
+
   return list.next;
 }
 
-static __inline__ 
-JSList* 
+static __inline__
+JSList*
 jack_slist_sort (JSList       *list,
 		 JCompareFunc compare_func)
 {
   JSList *l1, *l2;
 
-  if (!list) 
+  if (!list)
     return NULL;
-  if (!list->next) 
+  if (!list->next)
     return list;
 
-  l1 = list; 
+  l1 = list;
   l2 = list->next;
 
   while ((l2 = l2->next) != NULL)
     {
-      if ((l2 = l2->next) == NULL) 
+      if ((l2 = l2->next) == NULL)
 	break;
       l1=l1->next;
     }
-  l2 = l1->next; 
+  l2 = l1->next;
   l1->next = NULL;
 
   return jack_slist_sort_merge (jack_slist_sort (list, compare_func),

--- a/jslist.h
+++ b/jslist.h
@@ -21,8 +21,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_jslist_h__
-#define __jack_jslist_h__
+#ifndef JACK_JSLIST_H
+#define JACK_JSLIST_H
 
 #include <stdlib.h>
 
@@ -299,4 +299,4 @@ jack_slist_sort (JSList       *list,
 				compare_func);
 }
 
-#endif /* __jack_jslist_h__ */
+#endif /* JACK_JSLIST_H */

--- a/metadata.h
+++ b/metadata.h
@@ -1,20 +1,20 @@
 /*
-  Copyright (C) 2011-2014 David Robillard
-  Copyright (C) 2013 Paul Davis
+    Copyright (C) 2011-2014 David Robillard
+    Copyright (C) 2013 Paul Davis
 
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU Lesser General Public License as published by
-  the Free Software Foundation; either version 2.1 of the License, or (at
-  your option) any later version.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
 
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-  License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
 
-  You should have received a copy of the GNU Lesser General Public License
-  along with this program; if not, write to the Free Software Foundation,
-  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
 /**

--- a/metadata.h
+++ b/metadata.h
@@ -128,7 +128,7 @@ typedef struct {
  * Free a description.
  *
  * @param desc a jack_description_t whose associated memory will all be released
- * @param free_description_itself if non-zero, then @param desc will also be passed to free()
+ * @param free_description_itself if non-zero, then `desc` will also be passed to free()
  */
 void
 jack_free_description (jack_description_t* desc, int free_description_itself);
@@ -212,12 +212,12 @@ typedef void (*JackPropertyChangeCallback)(jack_uuid_t            subject,
                                            void*                  arg);
 
 /**
- * Arrange for @p client to call @p callback whenever a property is created,
+ * Arrange for `client` to call `callback` whenever a property is created,
  * changed or deleted.
  *
  * @param client the JACK client making the request
  * @param callback the function to be invoked when a property change occurs
- * @param arg the argument to be passed to @param callback when it is invoked
+ * @param arg the argument to be passed to `callback` when it is invoked
  *
  * @return 0 success, -1 otherwise.
  */

--- a/metadata.h
+++ b/metadata.h
@@ -24,8 +24,8 @@
  *
  */
 
-#ifndef __jack_metadata_h__
-#define __jack_metadata_h__
+#ifndef JACK_METADATA_H
+#define JACK_METADATA_H
 
 #include <jack/types.h>
 
@@ -319,4 +319,4 @@ extern const char* JACK_METADATA_SIGNAL_TYPE;
 } /* namespace */
 #endif
 
-#endif  /* __jack_metadata_h__ */
+#endif  /* JACK_METADATA_H */

--- a/midiport.h
+++ b/midiport.h
@@ -1,18 +1,18 @@
 /*
     Copyright (C) 2004 Ian Esten
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -24,12 +24,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	
+
 #include <jack/weakmacros.h>
 #include <jack/types.h>
 #include <stdlib.h>
 
-	
+
 /** Type for raw event data contained in @ref jack_midi_event_t. */
 typedef unsigned char jack_midi_data_t;
 
@@ -44,7 +44,7 @@ typedef struct _jack_midi_event
 
 
 /**
- * @defgroup MIDIAPI Reading and writing MIDI data 
+ * @defgroup MIDIAPI Reading and writing MIDI data
  * @{
  */
 
@@ -58,7 +58,7 @@ jack_midi_get_event_count(void*          port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
 
 
 /** Get a MIDI event from an event port buffer.
- * 
+ *
  * Jack MIDI is normalised, the MIDI event returned by this function is
  * guaranteed to be a complete MIDI event (the status byte will always be
  * present, and no realtime events will interspered with the event).
@@ -75,7 +75,7 @@ jack_midi_event_get(jack_midi_event_t *event,
 
 
 /** Clear an event buffer.
- * 
+ *
  * This should be called at the beginning of each process cycle before calling
  * @ref jack_midi_event_reserve or @ref jack_midi_event_write. This
  * function may not be called on an input port's buffer.
@@ -107,7 +107,7 @@ jack_midi_max_event_size(void* port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
  * when they occur on their own, like other messages).
  *
  * Events must be written in order, sorted by their sample offsets.
- * JACK will not sort the events for you, and will refuse to store 
+ * JACK will not sort the events for you, and will refuse to store
  * out-of-order events.
  *
  * @param port_buffer Buffer to write event to.
@@ -118,7 +118,7 @@ jack_midi_max_event_size(void* port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
  */
 jack_midi_data_t*
 jack_midi_event_reserve(void           *port_buffer,
-                        jack_nframes_t  time, 
+                        jack_nframes_t  time,
                         size_t          data_size) JACK_OPTIONAL_WEAK_EXPORT;
 
 
@@ -134,7 +134,7 @@ jack_midi_event_reserve(void           *port_buffer,
  * when they occur on their own, like other messages).
  *
  * Events must be written in order, sorted by their sample offsets.
- * JACK will not sort the events for you, and will refuse to store 
+ * JACK will not sort the events for you, and will refuse to store
  * out-of-order events.
  *
  * @param port_buffer Buffer to write event to.
@@ -170,5 +170,3 @@ jack_midi_get_lost_event_count(void           *port_buffer) JACK_OPTIONAL_WEAK_E
 
 
 #endif /* __JACK_MIDIPORT_H */
-
-

--- a/midiport.h
+++ b/midiport.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __JACK_MIDIPORT_H
-#define __JACK_MIDIPORT_H
+#ifndef JACK_MIDIPORT_H
+#define JACK_MIDIPORT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -166,5 +166,6 @@ jack_midi_get_lost_event_count(void           *port_buffer) JACK_OPTIONAL_WEAK_E
 }
 #endif
 
+#endif /* JACK_MIDIPORT_H */
 
-#endif /* __JACK_MIDIPORT_H */
+

--- a/midiport.h
+++ b/midiport.h
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
-
 
 #ifndef __JACK_MIDIPORT_H
 #define __JACK_MIDIPORT_H

--- a/ringbuffer.h
+++ b/ringbuffer.h
@@ -17,8 +17,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef _RINGBUFFER_H
-#define _RINGBUFFER_H
+#ifndef JACK_RINGBUFFER_H
+#define JACK_RINGBUFFER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -231,4 +231,4 @@ size_t jack_ringbuffer_write_space(const jack_ringbuffer_t *rb);
 }
 #endif
 
-#endif
+#endif /* JACK_RINGBUFFER_H */

--- a/ringbuffer.h
+++ b/ringbuffer.h
@@ -15,7 +15,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef _RINGBUFFER_H

--- a/ringbuffer.h
+++ b/ringbuffer.h
@@ -1,19 +1,19 @@
 /*
     Copyright (C) 2000 Paul Davis
     Copyright (C) 2003 Rohan Drape
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -41,11 +41,11 @@ extern "C" {
  * identities cannot be interchanged.
  */
 
-typedef struct  
+typedef struct
 {
   char  *buf;
   size_t len;
-} 
+}
 jack_ringbuffer_data_t ;
 
 typedef struct
@@ -56,7 +56,7 @@ typedef struct
   size_t	  size;
   size_t	  size_mask;
   int		  mlocked;
-} 
+}
 jack_ringbuffer_t ;
 
 /**

--- a/session.h
+++ b/session.h
@@ -18,8 +18,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_session_h__
-#define __jack_session_h__
+#ifndef JACK_SESSION_H
+#define JACK_SESSION_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -299,4 +299,5 @@ jack_client_has_session_callback (jack_client_t *client, const char *client_name
 #ifdef __cplusplus
 }
 #endif
-#endif
+
+#endif /* JACK_SESSION_H */

--- a/statistics.h
+++ b/statistics.h
@@ -1,16 +1,16 @@
 /*
  *  Copyright (C) 2004 Rui Nuno Capela, Lee Revell
- *  
+ *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
  *  as published by the Free Software Foundation; either version 2.1
  *  of the License, or (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Lesser General Public
  *  License along with this program; if not, write to the Free
  *  Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA

--- a/statistics.h
+++ b/statistics.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __statistics_h__
-#define __statistics_h__
+#ifndef JACK_STATISTICS_H
+#define JACK_STATISTICS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,4 +51,4 @@ void jack_reset_max_delayed_usecs (jack_client_t *client);
 }
 #endif
 
-#endif /* __statistics_h__ */
+#endif /* JACK_STATISTICS_H */

--- a/statistics.h
+++ b/statistics.h
@@ -1,22 +1,20 @@
 /*
- *  Copyright (C) 2004 Rui Nuno Capela, Lee Revell
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2.1
- *  of the License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *  Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this program; if not, write to the Free
- *  Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- *  02111-1307, USA.
- *
- */
+    Copyright (C) 2004 Rui Nuno Capela, Lee Revell
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*/
 
 #ifndef __statistics_h__
 #define __statistics_h__

--- a/systemdeps.h
+++ b/systemdeps.h
@@ -26,7 +26,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
         /* POST_PACKED_STRUCTURE needs to be a macro which
            expands into a compiler directive. The directive must
            tell the compiler to arrange the preceding structure
-           declaration so that it is packed on byte-boundaries rather 
+           declaration so that it is packed on byte-boundaries rather
            than use the natural alignment of the processor and/or
            compiler.
         */
@@ -35,7 +35,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
         #define POST_PACKED_STRUCTURE __attribute__((__packed__))
 
     #else
-    
+
         #ifdef _MSC_VER
             #define PRE_PACKED_STRUCTURE1 __pragma(pack(push,1))
             #define PRE_PACKED_STRUCTURE    PRE_PACKED_STRUCTURE1

--- a/systemdeps.h
+++ b/systemdeps.h
@@ -1,20 +1,19 @@
 /*
-Copyright (C) 2004-2012 Grame
+    Copyright (C) 2004-2012 Grame
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation; either version 2.1 of the License, or
-(at your option) any later version.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
 #ifndef __jack_systemdeps_h__

--- a/systemdeps.h
+++ b/systemdeps.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_systemdeps_h__
-#define __jack_systemdeps_h__
+#ifndef JACK_SYSTEMDEPS_H
+#define JACK_SYSTEMDEPS_H
 
 #ifndef POST_PACKED_STRUCTURE
 
@@ -137,4 +137,4 @@
     #define JACK_LIB_EXPORT
 #endif
 
-#endif /* __jack_systemdeps_h__ */
+#endif /* JACK_SYSTEMDEPS_H */

--- a/thread.h
+++ b/thread.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_thread_h__
-#define __jack_thread_h__
+#ifndef JACK_THREAD_H
+#define JACK_THREAD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -133,4 +133,4 @@ void jack_set_thread_creator (jack_thread_creator_t creator) JACK_OPTIONAL_WEAK_
 }
 #endif
 
-#endif /* __jack_thread_h__ */
+#endif /* JACK_THREAD_H */

--- a/thread.h
+++ b/thread.h
@@ -29,10 +29,10 @@ extern "C" {
 #include <jack/weakmacros.h>
 #include <jack/types.h>
 
-/* use 512KB stack per thread - the default is way too high to be feasible 
+/* use 512KB stack per thread - the default is way too high to be feasible
  * with mlockall() on many systems */
 #define THREAD_STACK 524288
-       
+
 /** @file thread.h
  *
  * Library functions to standardize thread creation for JACK and its
@@ -47,7 +47,7 @@ extern "C" {
 
 /**
  * @returns if JACK is running with realtime scheduling, this returns
- * the priority that any JACK-created client threads will run at. 
+ * the priority that any JACK-created client threads will run at.
  * Otherwise returns -1.
  */
 
@@ -115,16 +115,16 @@ typedef int (*jack_thread_creator_t)(jack_native_thread_t*,
  * are created by something other than pthread_create(). After
  * it is used, any threads that JACK needs for the client will
  * will be created by calling the function passed to this
- * function. 
+ * function.
  *
  * No normal application/client should consider calling this.
  * The specific case for which it was created involves running
  * win32/x86 plugins under Wine on Linux, where it is necessary
  * that all threads that might call win32 functions are known
  * to Wine.
- * 
+ *
  * @param creator a function that creates a new thread
- * 
+ *
  */
 void jack_set_thread_creator (jack_thread_creator_t creator) JACK_OPTIONAL_WEAK_EXPORT;
 

--- a/thread.h
+++ b/thread.h
@@ -14,7 +14,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef __jack_thread_h__

--- a/transport.h
+++ b/transport.h
@@ -15,7 +15,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef __jack_transport_h__

--- a/transport.h
+++ b/transport.h
@@ -17,8 +17,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_transport_h__
-#define __jack_transport_h__
+#ifndef JACK_TRANSPORT_H
+#define JACK_TRANSPORT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -536,4 +536,4 @@ void jack_set_transport_info (jack_client_t *client,
 }
 #endif
 
-#endif /* __jack_transport_h__ */
+#endif /* JACK_TRANSPORT_H */

--- a/transport.h
+++ b/transport.h
@@ -1,19 +1,19 @@
 /*
     Copyright (C) 2002 Paul Davis
     Copyright (C) 2003 Jack O'Quin
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -66,94 +66,94 @@ typedef enum {
  * Struct for transport position information.
  */
 typedef struct {
-    
+
     /*@{*/
     /** @name Server-set fields
      * these cannot be set from clients; the server sets them */
     jack_unique_t	unique_1;	/**< unique ID */
-    jack_time_t		usecs;		/**< microsecond timestamp that is guaranteed to be 
-                                             monotonic, but not neccessarily 
-                                             linear. 
+    jack_time_t		usecs;		/**< microsecond timestamp that is guaranteed to be
+                                             monotonic, but not neccessarily
+                                             linear.
 
-                                             The absolute value is 
+                                             The absolute value is
                                              implementation-dependent (i.e. it
-                                             could be wall-clock, time since 
+                                             could be wall-clock, time since
                                              jack started, uptime, etc). */
     jack_nframes_t	frame_rate;	/**< current frame rate, in frames per second */
     /*}@*/
 
     /*@{*/
-    /** @name Mandatory fields 
+    /** @name Mandatory fields
       */
-    jack_nframes_t	frame;		/**< frame number, always present/required. 
-                                             
-                                             This is the frame number on the 
-                                             transport timeline, which is not 
-                                             the same as what @ref 
+    jack_nframes_t	frame;		/**< frame number, always present/required.
+
+                                             This is the frame number on the
+                                             transport timeline, which is not
+                                             the same as what @ref
                                              jack_frame_time returns. */
     jack_position_bits_t valid;		/**< which other fields are valid, as a
-                                             bitmask constructed from values in 
+                                             bitmask constructed from values in
                                              \ref jack_position_bits_t */
     /*}@*/
 
     /*@{*/
-    /** @name JackPositionBBT fields 
-     * Bar:Beat.Tick-related information. 
+    /** @name JackPositionBBT fields
+     * Bar:Beat.Tick-related information.
      *
-     * Applications that support 
+     * Applications that support
      * JackPositionBBT are encouraged to also fill the JackBBTFrameOffset
      */
-    int32_t		bar;		/**< current bar 
+    int32_t		bar;		/**< current bar
 
-                                             Should be >0: the first bar is 
+                                             Should be >0: the first bar is
                                              bar '1'. */
-    int32_t		beat;		/**< current beat-within-bar 
+    int32_t		beat;		/**< current beat-within-bar
 
                                              Should be >0 and <=beats_per_bar:
                                              the first beat is beat '1'.
                                              */
-    int32_t		tick;		/**< current tick-within-beat 
+    int32_t		tick;		/**< current tick-within-beat
 
                                              Should be >= 0 and < ticks_per_beat:
                                              the first tick is tick '0'. */
-    double		bar_start_tick; /**< number of ticks that have elapsed 
+    double		bar_start_tick; /**< number of ticks that have elapsed
                                              between frame 0 and the first beat
                                              of the current measure. */
 
     float		beats_per_bar;	/**< time signature "numerator" */
     float		beat_type;	/**< time signature "denominator" */
-    double		ticks_per_beat; /**< number of ticks within a beat. 
+    double		ticks_per_beat; /**< number of ticks within a beat.
 
                                              Usually a moderately large integer
-                                             with many denominators, such as 
+                                             with many denominators, such as
                                              1920.0 */
     double		beats_per_minute; /**< BPM, quantized to block size. This
                                              means when the tempo is not constant
                                              within this block, the BPM value should
                                              adapted to compensate for this. This
                                              is different from most fields in this
-                                             struct, which specify the value at 
-                                             the beginning of the block rather 
+                                             struct, which specify the value at
+                                             the beginning of the block rather
                                              than an average.*/
     /*}@*/
 
     /*@{*/
-    /** @name JackPositionTimecode fields	
+    /** @name JackPositionTimecode fields
      * EXPERIMENTAL: could change */
     double		frame_time;	/**< current time in seconds */
     double		next_time;	/**< next sequential frame_time
 					     (unless repositioned) */
     /*}@*/
-  
+
     /*@{*/
     /* JackBBTFrameOffset fields */
     jack_nframes_t	bbt_offset;	/**< frame offset for the BBT fields
 					     (the given bar, beat, and tick
 					     values actually refer to a time
 					     frame_offset frames before the
-					     start of the cycle), should 
-					     be assumed to be 0 if 
-					     JackBBTFrameOffset is not 
+					     start of the cycle), should
+					     be assumed to be 0 if
+					     JackBBTFrameOffset is not
 					     set. If JackBBTFrameOffset is
 					     set and this value is zero, the BBT
 					     time refers to the first frame of this
@@ -227,11 +227,11 @@ typedef struct {
 int  jack_release_timebase (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
- * Prototype for the @a sync_callback defined by @ref slowsyncclients 
- * "slow-sync clients". When the client is active, this callback is 
- * invoked just before process() in the same thread.  This occurs once 
- * after registration, then subsequently whenever some client requests 
- * a new position, or the transport enters the ::JackTransportStarting 
+ * Prototype for the @a sync_callback defined by @ref slowsyncclients
+ * "slow-sync clients". When the client is active, this callback is
+ * invoked just before process() in the same thread.  This occurs once
+ * after registration, then subsequently whenever some client requests
+ * a new position, or the transport enters the ::JackTransportStarting
  * state.  This realtime function must not wait.
  *
  * The transport @a state will be:
@@ -246,7 +246,7 @@ int  jack_release_timebase (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  * @param arg the argument supplied by jack_set_sync_callback().
  *
  * @return TRUE (non-zero) when ready to roll.
- */ 
+ */
 typedef int  (*JackSyncCallback)(jack_transport_state_t state,
 				 jack_position_t *pos,
 				 void *arg);
@@ -323,9 +323,9 @@ int  jack_set_sync_timeout (jack_client_t *client,
  * @param new_pos TRUE (non-zero) for a newly requested @a pos, or for
  * the first cycle after the @a timebase_callback is defined.
  * @param arg the argument supplied by jack_set_timebase_callback().
- */ 
+ */
 typedef void (*JackTimebaseCallback)(jack_transport_state_t state,
-				     jack_nframes_t nframes, 
+				     jack_nframes_t nframes,
 				     jack_position_t *pos,
 				     int new_pos,
 				     void *arg);
@@ -366,13 +366,13 @@ int  jack_set_timebase_callback (jack_client_t *client,
  * Reposition the transport to a new frame number.
  *
  * May be called at any time by any client.  The new position takes
- * effect in two process cycles.  If there are @ref slowsyncclients 
- * "slow-sync clients" and the transport is already rolling, it will 
+ * effect in two process cycles.  If there are @ref slowsyncclients
+ * "slow-sync clients" and the transport is already rolling, it will
  * enter the ::JackTransportStarting state and begin invoking their @a
  * sync_callbacks until ready.  This function is realtime-safe.
  *
  * @see jack_transport_reposition, jack_set_sync_callback
- * 
+ *
  * @param client the JACK client structure.
  * @param frame frame number of new transport position.
  *
@@ -407,20 +407,20 @@ jack_transport_state_t jack_transport_query (const jack_client_t *client,
  * @param client the JACK client structure
  */
 jack_nframes_t jack_get_current_transport_frame (const jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
-						 
+
 /**
  * Request a new transport position.
  *
  * May be called at any time by any client.  The new position takes
- * effect in two process cycles.  If there are @ref slowsyncclients 
- * "slow-sync clients" and the transport is already rolling, it will 
+ * effect in two process cycles.  If there are @ref slowsyncclients
+ * "slow-sync clients" and the transport is already rolling, it will
  * enter the ::JackTransportStarting state and begin invoking their @a
  * sync_callbacks until ready.  This function is realtime-safe.
  *
  * @see jack_transport_locate, jack_set_sync_callback
- * 
+ *
  * @param client the JACK client structure.
- * @param pos requested new transport position. Fill pos->valid to specify 
+ * @param pos requested new transport position. Fill pos->valid to specify
  *   which fields should be taken into account. If you mark a set of fields
  *   as valid, you are expected to fill them all.
  *
@@ -481,14 +481,14 @@ typedef enum {
  * interface.  Use the jack_position_t struct, instead.
  */
 typedef struct {
-    
+
     /* these two cannot be set from clients: the server sets them */
 
     jack_nframes_t frame_rate;		/**< current frame rate (per second) */
     jack_time_t    usecs;		/**< monotonic, free-rolling */
 
     jack_transport_bits_t  valid;	/**< which fields are legal to read */
-    jack_transport_state_t transport_state;         
+    jack_transport_state_t transport_state;
     jack_nframes_t         frame;
     jack_nframes_t         loop_start;
     jack_nframes_t         loop_end;
@@ -499,7 +499,7 @@ typedef struct {
     int            bar;
     int            beat;
     int            tick;
-    double         bar_start_tick;            
+    double         bar_start_tick;
 
     float          beats_per_bar;
     float          beat_type;
@@ -507,7 +507,7 @@ typedef struct {
     double         beats_per_minute;
 
 } jack_transport_info_t;
-	
+
 /**
  * Gets the current transport info structure (deprecated).
  *

--- a/types.h
+++ b/types.h
@@ -375,10 +375,10 @@ typedef int  (*JackSampleRateCallback)(jack_nframes_t nframes, void *arg);
  *
  * @param port the ID of the port
  * @param arg pointer to a client supplied data
- * @param register non-zero if the port is being registered,
- *                     zero if the port is being unregistered
+ * @param registered non-zero if the port is being registered,
+ *                       zero if the port is being unregistered
  */
-typedef void (*JackPortRegistrationCallback)(jack_port_id_t port, int /* register */, void *arg);
+typedef void (*JackPortRegistrationCallback)(jack_port_id_t port, int registered, void *arg);
 
 /**
  * Prototype for the client supplied function that is called
@@ -396,11 +396,11 @@ typedef void (*JackPortRenameCallback)(jack_port_id_t port, const char* old_name
  * whenever a client is registered or unregistered.
  *
  * @param name a null-terminated string containing the client name
- * @param register non-zero if the client is being registered,
- *                     zero if the client is being unregistered
+ * @param registered non-zero if the client is being registered,
+ *                       zero if the client is being unregistered
  * @param arg pointer to a client supplied data
  */
-typedef void (*JackClientRegistrationCallback)(const char* name, int /* register */, void *arg);
+typedef void (*JackClientRegistrationCallback)(const char* name, int registered, void *arg);
 
 /**
  * Prototype for the client supplied function that is called

--- a/types.h
+++ b/types.h
@@ -17,8 +17,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_types_h__
-#define __jack_types_h__
+#ifndef JACK_TYPES_H
+#define JACK_TYPES_H
 
 #include <inttypes.h>
 #include <pthread.h>
@@ -526,4 +526,4 @@ enum JackPortFlags {
 };
 
 
-#endif /* __jack_types_h__ */
+#endif /* JACK_TYPES_H */

--- a/types.h
+++ b/types.h
@@ -1,19 +1,19 @@
 /*
     Copyright (C) 2001 Paul Davis
     Copyright (C) 2004 Jack O'Quin
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -268,12 +268,12 @@ enum JackLatencyCallbackMode {
 typedef enum JackLatencyCallbackMode jack_latency_callback_mode_t;
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * by the engine when port latencies need to be recalculated
  *
  * @param mode playback or capture latency
  * @param arg pointer to a client supplied data
- */ 
+ */
 typedef void (*JackLatencyCallback)(jack_latency_callback_mode_t mode, void *arg);
 
 /**
@@ -294,7 +294,7 @@ struct _jack_latency_range
 typedef struct _jack_latency_range jack_latency_range_t;
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * by the engine anytime there is work to be done.
  *
  * @pre nframes == jack_get_buffer_size()
@@ -304,11 +304,11 @@ typedef struct _jack_latency_range jack_latency_range_t;
  * @param arg pointer to a client supplied data
  *
  * @return zero on success, non-zero on error
- */ 
+ */
 typedef int  (*JackProcessCallback)(jack_nframes_t nframes, void *arg);
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * once after the creation of the thread in which other
  * callbacks will be made. Special thread characteristics
  * can be set from this callback, for example. This is a
@@ -318,17 +318,17 @@ typedef int  (*JackProcessCallback)(jack_nframes_t nframes, void *arg);
  * @param arg pointer to a client supplied structure
  *
  * @return void
- */ 
+ */
 typedef void  (*JackThreadInitCallback)(void *arg);
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * whenever the processing graph is reordered.
  *
  * @param arg pointer to a client supplied data
  *
  * @return zero on success, non-zero on error
- */ 
+ */
 typedef int  (*JackGraphOrderCallback)(void *arg);
 
 /**
@@ -340,7 +340,7 @@ typedef int  (*JackGraphOrderCallback)(void *arg);
  * @param arg pointer to a client supplied data
  *
  * @return zero on success, non-zero on error
- */ 
+ */
 typedef int  (*JackXRunCallback)(void *arg);
 
 /**
@@ -356,55 +356,55 @@ typedef int  (*JackXRunCallback)(void *arg);
  * @param arg pointer supplied by jack_set_buffer_size_callback().
  *
  * @return zero on success, non-zero on error
- */ 
+ */
 typedef int  (*JackBufferSizeCallback)(jack_nframes_t nframes, void *arg);
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * when the engine sample rate changes.
  *
  * @param nframes new engine sample rate
  * @param arg pointer to a client supplied data
  *
  * @return zero on success, non-zero on error
- */ 
+ */
 typedef int  (*JackSampleRateCallback)(jack_nframes_t nframes, void *arg);
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * whenever a port is registered or unregistered.
  *
- * @param port the ID of the port 
+ * @param port the ID of the port
  * @param arg pointer to a client supplied data
  * @param register non-zero if the port is being registered,
  *                     zero if the port is being unregistered
- */ 
+ */
 typedef void (*JackPortRegistrationCallback)(jack_port_id_t port, int /* register */, void *arg);
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * whenever a port is renamed
  *
- * @param port the ID of the port 
+ * @param port the ID of the port
  * @param arg pointer to a client supplied data
  * @param old_name the name of the port before the rename was carried out
  * @param new_name the name of the port after the rename was carried out
- */ 
+ */
 typedef void (*JackPortRenameCallback)(jack_port_id_t port, const char* old_name, const char* new_name, void* arg);
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * whenever a client is registered or unregistered.
  *
- * @param name a null-terminated string containing the client name 
+ * @param name a null-terminated string containing the client name
  * @param register non-zero if the client is being registered,
  *                     zero if the client is being unregistered
  * @param arg pointer to a client supplied data
- */ 
+ */
 typedef void (*JackClientRegistrationCallback)(const char* name, int /* register */, void *arg);
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * whenever ports are connected or disconnected.
  *
  * @param a one of two ports connected or disconnected
@@ -412,11 +412,11 @@ typedef void (*JackClientRegistrationCallback)(const char* name, int /* register
  * @param connect non-zero if ports were connected
  *                    zero if ports were disconnected
  * @param arg pointer to a client supplied data
- */ 
+ */
 typedef void (*JackPortConnectCallback)(jack_port_id_t a, jack_port_id_t b, int connect, void* arg);
 
 /**
- * Prototype for the client supplied function that is called 
+ * Prototype for the client supplied function that is called
  * whenever jackd starts or stops freewheeling.
  *
  * @param starting non-zero if we start starting to freewheel, zero otherwise
@@ -492,7 +492,7 @@ enum JackPortFlags {
       * if JackPortIsPhysical is set, then the port corresponds
       * to some kind of physical I/O connector.
       */
-     JackPortIsPhysical = 0x4, 
+     JackPortIsPhysical = 0x4,
 
      /**
       * if JackPortCanMonitor is set, then a call to
@@ -503,7 +503,7 @@ enum JackPortFlags {
       * that data that would be available from an output port (with
       * JackPortIsPhysical set) is sent to a physical output connector
       * as well, so that it can be heard/seen/whatever.
-      * 
+      *
       * Clients that do not control physical interfaces
       * should never create ports with this bit set.
       */
@@ -524,7 +524,7 @@ enum JackPortFlags {
       * their ports.
       */
      JackPortIsTerminal = 0x10
-};	    
+};
 
 
 #endif /* __jack_types_h__ */

--- a/types.h
+++ b/types.h
@@ -15,7 +15,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef __jack_types_h__

--- a/uuid.h
+++ b/uuid.h
@@ -14,7 +14,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef __jack_uuid_h__

--- a/uuid.h
+++ b/uuid.h
@@ -1,18 +1,18 @@
 /*
     Copyright (C) 2013 Paul Davis
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -47,4 +47,3 @@ extern int  jack_uuid_empty (jack_uuid_t);
 #endif
 
 #endif /* __jack_uuid_h__ */
-

--- a/uuid.h
+++ b/uuid.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __jack_uuid_h__
-#define __jack_uuid_h__
+#ifndef JACK_UUID_H
+#define JACK_UUID_H
 
 #include <jack/types.h>
 
@@ -45,4 +45,4 @@ extern int  jack_uuid_empty (jack_uuid_t);
 } /* namespace */
 #endif
 
-#endif /* __jack_uuid_h__ */
+#endif /* JACK_UUID_H */

--- a/weakjack.h
+++ b/weakjack.h
@@ -1,18 +1,18 @@
 /*
     Copyright (C) 2010 Paul Davis
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -44,19 +44,19 @@
  *    the framework, the code module can continue to run as
  *    long as it does not reference the symbol. However, if
  *    the symbol is present, the code can use it normally.
- * 
+ *
  *        (adapted from: http://developer.apple.com/library/mac/#documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WeakLinking.html)
  *
  *    A concrete example will help. Suppose that someone uses a version
  *    of a JACK client we'll call "Jill". Jill was linked against a version
  *    of JACK that contains a newer part of the API (say, jack_set_latency_callback())
  *    and would like to use it if it is available.
- *  
+ *
  *    When Jill is run on a system that has a suitably "new" version of
  *    JACK, this function will be available entirely normally. But if Jill
  *    is run on a system with an old version of JACK, the function isn't
- *    available. 
- *   
+ *    available.
+ *
  *    With normal symbol linkage, this would create a startup error whenever
  *    someone tries to run Jill with the "old" version of JACK. However, functions
  *    added to JACK after version 0.116.2 are all declared to have "weak" linkage
@@ -76,13 +76,13 @@
  *    the JACK API that predate 0.116.2. For example, they might want to see if even
  *    really old basic parts of the API like jack_client_open() exist at runtime.
  *
- *    Such clients should include <jack/weakjack.h> before any other JACK header. 
+ *    Such clients should include <jack/weakjack.h> before any other JACK header.
  *    This will make the \b entire JACK API be subject to weak linkage, so that any
  *    and all functions can be checked for existence at runtime. It is important
  *    to understand that very few clients need to do this - if you use this
  *    feature you should have a clear reason to do so.
- *     
- * 
+ *
+ *
  */
 
 #ifdef __APPLE__
@@ -93,8 +93,8 @@
 
 #ifndef JACK_OPTIONAL_WEAK_EXPORT
 /* JACK_OPTIONAL_WEAK_EXPORT needs to be a macro which
-   expands into a compiler directive. If non-null, the directive 
-   must tell the compiler to arrange for weak linkage of 
+   expands into a compiler directive. If non-null, the directive
+   must tell the compiler to arrange for weak linkage of
    the symbol it used with. For this to work fully may
    require linker arguments for the client as well.
 */

--- a/weakjack.h
+++ b/weakjack.h
@@ -14,7 +14,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef __weakjack_h__

--- a/weakjack.h
+++ b/weakjack.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __weakjack_h__
-#define __weakjack_h__
+#ifndef JACK_WEAKJACK_H
+#define JACK_WEAKJACK_H
 
 /**
  * @defgroup WeakLinkage managing support for newer/older versions of JACK
@@ -121,4 +121,4 @@
 
 /*@}*/
 
-#endif /* weakjack */
+#endif /* JACK_WEAKJACK_H */

--- a/weakmacros.h
+++ b/weakmacros.h
@@ -1,18 +1,18 @@
 /*
     Copyright (C) 2010 Paul Davis
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2.1 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software 
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
@@ -23,12 +23,12 @@
 /*************************************************************
  * NOTE: JACK_WEAK_EXPORT ***MUST*** be used on every function
  * added to the JACK API after the 0.116.2 release.
- * 
- * Functions that predate this release are marked with 
+ *
+ * Functions that predate this release are marked with
  * JACK_WEAK_OPTIONAL_EXPORT which can be defined at compile
  * time in a variety of ways. The default definition is empty,
  * so that these symbols get normal linkage. If you wish to
- * use all JACK symbols with weak linkage, include 
+ * use all JACK symbols with weak linkage, include
  * <jack/weakjack.h> before jack.h.
  *************************************************************/
 
@@ -41,8 +41,8 @@
 #ifndef JACK_WEAK_EXPORT
 #ifdef __GNUC__
 /* JACK_WEAK_EXPORT needs to be a macro which
-   expands into a compiler directive. If non-null, the directive 
-   must tell the compiler to arrange for weak linkage of 
+   expands into a compiler directive. If non-null, the directive
+   must tell the compiler to arrange for weak linkage of
    the symbol it used with. For this to work full may
    require linker arguments in the client as well.
 */

--- a/weakmacros.h
+++ b/weakmacros.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#ifndef __weakmacros_h__
-#define __weakmacros_h__
+#ifndef JACK_WEAKMACROS_H
+#define JACK_WEAKMACROS_H
 
 /*************************************************************
  * NOTE: JACK_WEAK_EXPORT ***MUST*** be used on every function
@@ -63,4 +63,4 @@
 #endif /* __GNUC__ */
 #endif
 
-#endif /* __weakmacros_h__ */
+#endif /* JACK_WEAKMACROS_H */

--- a/weakmacros.h
+++ b/weakmacros.h
@@ -14,7 +14,6 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
 */
 
 #ifndef __weakmacros_h__


### PR DESCRIPTION
Fixes various warnings that the public API headers can trigger in client code, and does some tidying up along the way.

Shouldn't be any non-superficial changes.